### PR TITLE
Clarify README.MD's title heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scheme listings in LaTeX
+# Scheme syntax highlight for the "listings" package in LaTeX
 
 ## Example
 


### PR DESCRIPTION
Clarify the title's heading. Rationale: for the unintroduced that "listings" means "language-specific syntax highlight" is unobvious.